### PR TITLE
[Autopilot] approval for rule pgbench/test1-pvc-49c4739e-a3e9-4878-9f54-6ed55ca160d2 rule: test1

### DIFF
--- a/workloads/test1-pvc-49c4739e-a3e9-4878-9f54-6ed55ca160d2-284c531e-0301-47f9-9813-abd0f92b1f5f.yaml
+++ b/workloads/test1-pvc-49c4739e-a3e9-4878-9f54-6ed55ca160d2-284c531e-0301-47f9-9813-abd0f92b1f5f.yaml
@@ -1,0 +1,21 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: ActionApproval
+metadata:
+  creationTimestamp: null
+  labels:
+    rule: test1
+  name: test1-pvc-49c4739e-a3e9-4878-9f54-6ed55ca160d2
+  namespace: pgbench
+  uid: 62558813-a8b1-48a9-ac35-4205670682e7
+spec:
+  actions:
+  - name: resize
+    params:
+      maxsize: 12Gi
+      scalepercentage: "10"
+  approvalState: approved
+status:
+  Rule:
+    Name: ""
+    Namespace: ""
+  lastProcessTimestamp: null


### PR DESCRIPTION


This is a request to approve an autopilot action. The request was triggered based on an AutopilotRule __test1__ defined in your cluster.


## What actions will be taken

### Action: resize

- __Params__: map[maxsize:12Gi scalepercentage:10]
- __ExpectedResult__: PVC will resize from 10Gi to 11Gi

 
#### What objects will get affected

- PersistentVolumeClaim pgbench/pgbench-data1 (pvc-49c4739e-a3e9-4878-9f54-6ed55ca160d2)
  - Object Owner(s):
    - ReplicaSet pgbench-65849f84bd      

## How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
