### PR TITLE
[Autopilot] approval for rule pgbench/test1-pvc-e92e18fd-bef2-4ac2-a6b0-a6f2e5137043 rule: test1

### DIFF
--- a/workloads/test1-pvc-e92e18fd-bef2-4ac2-a6b0-a6f2e5137043-bd5467b2-2051-4dc9-b417-a3f311492206.yaml
+++ b/workloads/test1-pvc-e92e18fd-bef2-4ac2-a6b0-a6f2e5137043-bd5467b2-2051-4dc9-b417-a3f311492206.yaml
@@ -1,0 +1,21 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: ActionApproval
+metadata:
+  creationTimestamp: null
+  labels:
+    rule: test1
+  name: test1-pvc-e92e18fd-bef2-4ac2-a6b0-a6f2e5137043
+  namespace: pgbench
+  uid: 5eb78146-9803-48fc-bf8e-7207fb34d894
+spec:
+  actions:
+  - name: resize
+    params:
+      maxsize: 12Gi
+      scalepercentage: "10"
+  approvalState: approved
+status:
+  Rule:
+    Name: ""
+    Namespace: ""
+  lastProcessTimestamp: null


### PR DESCRIPTION


This is a request to approve an autopilot action. The request was triggered based on an AutopilotRule __test1__ defined in your cluster.


## What actions will be taken

### Action: resize

- __Params__: map[maxsize:12Gi scalepercentage:10]
- __ExpectedResult__: PVC will resize from 10Gi to 11Gi

 
#### What objects will get affected

- PersistentVolumeClaim pgbench/pgbench-data1 (pvc-e92e18fd-bef2-4ac2-a6b0-a6f2e5137043)
  - Object Owner(s):
    - ReplicaSet pgbench-65849f84bd      

## How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
