### PR TITLE
[Autopilot] approval for rule pgbench/test1-pvc-3056e7bf-552e-4db2-b6a9-19ce4d89272f rule: test1

### DIFF
--- a/workloads/test1-pvc-3056e7bf-552e-4db2-b6a9-19ce4d89272f-1d486e0a-e2a6-4ac0-9231-0e357a22325f.yaml
+++ b/workloads/test1-pvc-3056e7bf-552e-4db2-b6a9-19ce4d89272f-1d486e0a-e2a6-4ac0-9231-0e357a22325f.yaml
@@ -1,0 +1,21 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: ActionApproval
+metadata:
+  creationTimestamp: null
+  labels:
+    rule: test1
+  name: test1-pvc-3056e7bf-552e-4db2-b6a9-19ce4d89272f
+  namespace: pgbench
+  uid: 0be69aef-1879-49e9-aae6-36d7c512437e
+spec:
+  actions:
+  - name: resize
+    params:
+      maxsize: 12Gi
+      scalepercentage: "10"
+  approvalState: approved
+status:
+  Rule:
+    Name: ""
+    Namespace: ""
+  lastProcessTimestamp: null


### PR DESCRIPTION


This is a request to approve an autopilot action. The request was triggered based on an AutopilotRule __test1__ defined in your cluster.


## What actions will be taken

### Action: resize

- __Params__: map[maxsize:12Gi scalepercentage:10]
- __ExpectedResult__: PVC will resize from 10Gi to 11Gi

 
#### What objects will get affected

- PersistentVolumeClaim pgbench/pgbench-data (pvc-3056e7bf-552e-4db2-b6a9-19ce4d89272f)
  - Object Owner(s):
    - ReplicaSet pgbench-65849f84bd      

## How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
