### PR TITLE
[Autopilot] approval for rule pgbench/test1-pvc-bdd0b10a-9ca2-4d26-ac50-a8ad92efa273 rule: test1

### DIFF
--- a/workloads/test1-pvc-bdd0b10a-9ca2-4d26-ac50-a8ad92efa273-28e0d0cb-584f-48bf-8d76-debbce0b163e.yaml
+++ b/workloads/test1-pvc-bdd0b10a-9ca2-4d26-ac50-a8ad92efa273-28e0d0cb-584f-48bf-8d76-debbce0b163e.yaml
@@ -1,0 +1,21 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: ActionApproval
+metadata:
+  creationTimestamp: null
+  labels:
+    rule: test1
+  name: test1-pvc-bdd0b10a-9ca2-4d26-ac50-a8ad92efa273
+  namespace: pgbench
+  uid: 34ca4a6f-fbaa-419f-916d-dc5248994f31
+spec:
+  actions:
+  - name: resize
+    params:
+      maxsize: 12Gi
+      scalepercentage: "10"
+  approvalState: approved
+status:
+  Rule:
+    Name: ""
+    Namespace: ""
+  lastProcessTimestamp: null


### PR DESCRIPTION


This is a request to approve an autopilot action. The request was triggered based on an AutopilotRule __test1__ defined in your cluster.


## What actions will be taken

### Action: resize

- __Params__: map[maxsize:12Gi scalepercentage:10]
- __ExpectedResult__: PVC will resize from 10Gi to 11Gi

 
#### What objects will get affected

- PersistentVolumeClaim pgbench/pgbench-data (pvc-bdd0b10a-9ca2-4d26-ac50-a8ad92efa273)
  - Object Owner(s):
    - ReplicaSet pgbench-65849f84bd      

## How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
