### PR TITLE
[Autopilot] approval for rule pgbench/test1-pvc-e8aa8b55-2e18-4b11-a851-3af154922538 rule: test1

### DIFF
--- a/workloads/test1-pvc-e8aa8b55-2e18-4b11-a851-3af154922538-63bfaf48-00e2-4f59-9388-d790a6b1ad80.yaml
+++ b/workloads/test1-pvc-e8aa8b55-2e18-4b11-a851-3af154922538-63bfaf48-00e2-4f59-9388-d790a6b1ad80.yaml
@@ -1,0 +1,21 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: ActionApproval
+metadata:
+  creationTimestamp: null
+  labels:
+    rule: test1
+  name: test1-pvc-e8aa8b55-2e18-4b11-a851-3af154922538
+  namespace: pgbench
+  uid: 7c54f1ca-48c4-417f-bde8-e04f60c8ede6
+spec:
+  actions:
+  - name: resize
+    params:
+      maxsize: 12Gi
+      scalepercentage: "10"
+  approvalState: approved
+status:
+  Rule:
+    Name: ""
+    Namespace: ""
+  lastProcessTimestamp: null


### PR DESCRIPTION


This is a request to approve an autopilot action. The request was triggered based on an AutopilotRule __test1__ defined in your cluster.


## What actions will be taken

### Action: resize

- __Params__: map[maxsize:12Gi scalepercentage:10]
- __ExpectedResult__: PVC will resize from 10Gi to 11Gi

 
#### What objects will get affected

- PersistentVolumeClaim pgbench/pgbench-data (pvc-e8aa8b55-2e18-4b11-a851-3af154922538)
  - Object Owner(s):
    - ReplicaSet pgbench-65849f84bd      

## How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
