### PR TITLE
[Autopilot] approval for rule pgbench/test1-pvc-838dab6a-64db-413e-8915-25742a8a2a02 rule: test1

### DIFF
--- a/workloads/test1-pvc-838dab6a-64db-413e-8915-25742a8a2a02-abce1e3a-9d18-4567-ada4-249993bf444d.yaml
+++ b/workloads/test1-pvc-838dab6a-64db-413e-8915-25742a8a2a02-abce1e3a-9d18-4567-ada4-249993bf444d.yaml
@@ -1,0 +1,40 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: ActionApproval
+metadata:
+  creationTimestamp: null
+  labels:
+    object: pvc-838dab6a-64db-413e-8915-25742a8a2a02
+    rule: test1
+  name: test1-pvc-838dab6a-64db-413e-8915-25742a8a2a02
+  namespace: pgbench
+spec:
+  actions:
+  - name: resize
+    params:
+      scalepercentage: "1"
+  approvalState: approved
+status:
+  Rule:
+    Name: test1
+    Namespace: ""
+  actionPreviews:
+  - action:
+      name: resize
+      params:
+        scalepercentage: "1"
+    expectedResult:
+      Message: PVC will resize from 10Gi to 10844792422
+    involvedObjects:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      name: pgbench-data
+      namespace: pgbench
+      ownerReferences:
+      - apiVersion: apps/v1
+        blockOwnerDeletion: true
+        controller: true
+        kind: ReplicaSet
+        name: pgbench-65849f84bd
+        uid: 865b124e-beeb-4b87-83c0-8ed459048a5d
+      uid: pvc-838dab6a-64db-413e-8915-25742a8a2a02
+  lastProcessTimestamp: "2020-08-28T03:42:04Z"


### PR DESCRIPTION


This is a request to approve an autopilot action. The request was triggered based on an AutopilotRule __test1__ defined in your cluster.


## What actions will be taken

### Action: resize

- __Params__: map[scalepercentage:1]
- __ExpectedResult__: PVC will resize from 10Gi to 10844792422

 
#### What objects will get affected

- PersistentVolumeClaim pgbench/pgbench-data (pvc-838dab6a-64db-413e-8915-25742a8a2a02)
  - Object Owner(s):
    - ReplicaSet pgbench-65849f84bd      

## How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
