### PR TITLE
[Autopilot] approval for rule pgbench/test1-pvc-ddeb72be-f422-4599-b05f-a836cb101c78 rule: test1

### DIFF
--- a/workloads/test1-pvc-ddeb72be-f422-4599-b05f-a836cb101c78-dedf9202-3cb0-4584-b575-34c2a6ffaa37.yaml
+++ b/workloads/test1-pvc-ddeb72be-f422-4599-b05f-a836cb101c78-dedf9202-3cb0-4584-b575-34c2a6ffaa37.yaml
@@ -1,0 +1,42 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: ActionApproval
+metadata:
+  creationTimestamp: null
+  finalizers:
+  - autopilot.libopenstorage.org/delete
+  labels:
+    object: pvc-ddeb72be-f422-4599-b05f-a836cb101c78
+    rule: test1
+  name: test1-pvc-ddeb72be-f422-4599-b05f-a836cb101c78
+  namespace: pgbench
+spec:
+  actions:
+  - name: resize
+    params:
+      scalepercentage: "1"
+  approvalState: approved
+status:
+  Rule:
+    Name: test1
+    Namespace: ""
+  actionPreviews:
+  - action:
+      name: resize
+      params:
+        scalepercentage: "1"
+    expectedResult:
+      Message: PVC will resize from 10Gi to 10844792422
+    involvedObjects:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      name: pgbench-data
+      namespace: pgbench
+      ownerReferences:
+      - apiVersion: apps/v1
+        blockOwnerDeletion: true
+        controller: true
+        kind: ReplicaSet
+        name: pgbench-57f9d94764
+        uid: 7d579dd7-6ded-41b1-9798-0883a36139c5
+      uid: pvc-ddeb72be-f422-4599-b05f-a836cb101c78
+  lastProcessTimestamp: "2020-09-01T23:24:06Z"


### PR DESCRIPTION


This is a request to approve an autopilot action. The request was triggered based on an AutopilotRule __test1__ defined in your cluster.


## What actions will be taken

### Action: resize

- __Params__: map[scalepercentage:1]

#### ExpectedResult

PVC will resize from 10Gi to 10844792422
 
#### What objects will get affected

- PersistentVolumeClaim pgbench/pgbench-data (pvc-ddeb72be-f422-4599-b05f-a836cb101c78)
  - Object Owner(s):
    - ReplicaSet pgbench-57f9d94764      

## How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
